### PR TITLE
fix: account for changed thread element composition

### DIFF
--- a/content.js
+++ b/content.js
@@ -161,7 +161,7 @@ function main() {
                         }, 1000);
                     });
 
-                    var buttonContainer = e.querySelector('div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(1) > div:nth-of-type(1) > span:nth-of-type(1)');
+                    var buttonContainer = e.querySelector('div[aria-label="Follow"] > span:first-of-type');
                     if (
                         buttonContainer &&
                         buttonContainer.children.length === 2 &&

--- a/content.js
+++ b/content.js
@@ -172,6 +172,10 @@ function main() {
 
                         buttonContainer.parentElement.style = 'display: inline-block; width: unset; opacity: 1;';
                         buttonContainer.parentElement.parentElement.appendChild(copyButton);
+
+                        // Follow button container gets hidden in channels where all notifications are enabled.
+                        // Undo that
+                        buttonContainer.parentElement.parentElement.parentElement.style += '; display: block;';
                         copyButtonInsertedCount += 1;
                         scrollContainer.scrollTop += 36;
                         buttonContainer.parentElement.parentElement.parentElement.parentElement.style = 'padding-top: 56px;';

--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -126,6 +126,14 @@
         document.head.appendChild(styleElement);
     }
     
+    function inIframe () {
+        try {
+            return window.self !== window.top;
+        } catch (e) {
+            return true;
+        }
+    }
+    
     function main() {
         var scrollContainer = document.querySelector('c-wiz[data-group-id][data-is-client-side] > div:nth-child(1)');
         var copyButtonInsertedCount = 0;
@@ -143,9 +151,16 @@
                         `;
                         copyButton.addEventListener('click', function() {
                             const el = document.createElement('textarea');
-                            const roomId = window.location.pathname.match(/\/room\/([^\?\/]*)/)[1];
                             const threadId = e.getAttribute("data-topic-id");
-                            el.value = `https://chat.google.com/room/${roomId}/${threadId}`;
+                            if (inIframe()) {
+                                // The new mail.google.com/chat application uses iframes that point to chat.google.com
+                                // Rooms are now renamed to spaces. Getting the space id from an attribute in the element
+                                const roomId = e.getAttribute('data-p').match(/space\/([^\\"]*)/)[1];
+                                el.value = `https://mail.google.com/chat/#chat/space/${roomId}/${threadId}`;
+                            } else {
+                                const roomId = window.location.pathname.match(/\/room\/([^\?\/]*)/)[1];
+                                el.value = `https://chat.google.com/room/${roomId}/${threadId}`;
+                            }
                             document.body.appendChild(el);
                             el.select();
                             document.execCommand('copy');
@@ -156,7 +171,7 @@
                                 copyButton.removeAttribute('data-tooltip');
                             }, 1000);
                         });
-
+    
                         var buttonContainer = e.querySelector('div[aria-label="Follow"] > span:first-of-type');
                         if (
                             buttonContainer &&
@@ -168,6 +183,10 @@
     
                             buttonContainer.parentElement.style = 'display: inline-block; width: unset; opacity: 1;';
                             buttonContainer.parentElement.parentElement.appendChild(copyButton);
+    
+                            // Follow button container gets hidden in channels where all notifications are enabled.
+                            // Undo that
+                            buttonContainer.parentElement.parentElement.parentElement.style += '; display: block;';
                             copyButtonInsertedCount += 1;
                             scrollContainer.scrollTop += 36;
                             buttonContainer.parentElement.parentElement.parentElement.parentElement.style = 'padding-top: 56px;';

--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -156,8 +156,8 @@
                                 copyButton.removeAttribute('data-tooltip');
                             }, 1000);
                         });
-    
-                        var buttonContainer = e.querySelector('div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(1) > div:nth-of-type(1) > span:nth-of-type(1)');
+
+                        var buttonContainer = e.querySelector('div[aria-label="Follow"] > span:first-of-type');
                         if (
                             buttonContainer &&
                             buttonContainer.children.length === 2 &&


### PR DESCRIPTION
This extension recently stopped working for my team members, not sure exactly when. I'm seeing a different element composition in the message thread, resulting in the follow buttons not being found. I noticed everything is labeled for accessibility, so used that to hopefully make it a little more reliable across updates.   